### PR TITLE
add launch.json for better debugging experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Package",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${fileDirname}/main.go"
+    }
+  ]
+}


### PR DESCRIPTION
添加vscode调试配置文件launch.json. 调试的对象是main.go，但仍然可以对整个项目进行调试。开启调试时，转到main.go文件，点击最上方`Run -> Start Debugging` 即可开始调试，或者直接按F5开始调试。