### PR TITLE
set zap time encoder to zapcore.ISO8601TimeEncoder

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,6 +60,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
#9 修改了一行代码，设置zap的timer encoder为zapcore.ISO8601TimeEncoder，替换原来默认打印时间戳的time encoder
目前日志的格式：
2023-01-12T11:04:20.002+0800    INFO    Starting EventSource    {"controller": "function", "controllerGroup": "openrhino.org", "controllerKind": "Function", "source": "kind source: *v1alpha1.Function"}

google了一圈，也没有找到格式化后面json的方法，就姑且不再找了。输出的结构体不是自定义的，输出日志的信息中还有json object的嵌套，实现String()方法也比较困难，而且zap日志库不支持使用fmt string的格式化(为提高性能)，就暂且搁置，等到输出json序列太长导致很难获取debug信息时再考虑进一步格式化日志信息