### PR TITLE
set defalut image repo to docker.io/openrhino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= docker.io/openrhino/controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: docker.io/openrhino/controller
   newTag: latest


### PR DESCRIPTION
`make docker-build` and `make  deploy` will use this repo by default (The image tag will be `docker.io/openrhino/controller:latest`)  which is the official image repo of OpenRHINO.
Developers can set env variable `IMG` to use another repo.