### PR TITLE
change package name

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: openrhino.org
 layout:
 - go.kubebuilder.io/v3
 projectName: rhino-operator
-repo: openrhino.org/operator
+repo: github.com/OpenRHINO/RHINO-Operator
 resources:
 - api:
     crdVersion: v1
@@ -10,7 +10,7 @@ resources:
   controller: true
   domain: openrhino.org
   kind: Function
-  path: openrhino.org/operator/api/v1alpha1
+  path: github.com/OpenRHINO/RHINO-Operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -18,6 +18,6 @@ resources:
   controller: true
   domain: openrhino.org
   kind: RhinoJob
-  path: openrhino.org/operator/api/v1alpha1
+  path: github.com/OpenRHINO/RHINO-Operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/controllers/function_controller.go
+++ b/controllers/function_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openrhinoorgv1alpha1 "openrhino.org/operator/api/v1alpha1"
+	openrhinoorgv1alpha1 "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
 )
 
 // FunctionReconciler reconciles a Function object

--- a/controllers/rhinojob_controller.go
+++ b/controllers/rhinojob_controller.go
@@ -32,7 +32,7 @@ import (
 	kcorev1 "k8s.io/api/core/v1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	rhinooprapiv1alpha1 "openrhino.org/operator/api/v1alpha1" //这里导入后的名字跟脚手架代码自动生成的不一样，这样改的原因是为了可读性更好
+	rhinooprapiv1alpha1 "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1" //这里导入后的名字跟脚手架代码自动生成的不一样，这样改的原因是为了可读性更好
 )
 
 // RhinoJobReconciler reconciles a RhinoJob object

--- a/controllers/rhinojob_controller_test.go
+++ b/controllers/rhinojob_controller_test.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	rhinooprapiv1alpha1 "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
 	kbatchv1 "k8s.io/api/batch/v1"
-	rhinooprapiv1alpha1 "openrhino.org/operator/api/v1alpha1"
 )
 
 var _ = Describe("RhinoJob controller", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	openrhinoorgv1alpha1 "openrhino.org/operator/api/v1alpha1"
+	openrhinoorgv1alpha1 "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module openrhino.org/operator
+module github.com/OpenRHINO/RHINO-Operator
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	openrhinoorgv1alpha1 "openrhino.org/operator/api/v1alpha1"
-	"openrhino.org/operator/controllers"
+	openrhinoorgv1alpha1 "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
+	"github.com/OpenRHINO/RHINO-Operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
change package name from 'openrhino.org/operator' to 'github.com/OpenRHINO/RHINO-Operator for users to download package from github