### PR TITLE
Health probe

### DIFF
--- a/controllers/rhinojob_controller.go
+++ b/controllers/rhinojob_controller.go
@@ -200,14 +200,15 @@ func (r *RhinoJobReconciler) constructLauncherJob(rj *rhinooprapiv1alpha1.RhinoJ
 						Name:    "rhino-mpi-launcher",
 						Command: []string{"mpirun"},
 						Args:    cmdArgs,
-						StartupProbe: &kcorev1.Probe{
+						ReadinessProbe: &kcorev1.Probe{
 							ProbeHandler: kcorev1.ProbeHandler{
 								Exec: &kcorev1.ExecAction{
-									Command: []string{"/bin/sh", "-c", "echo MPI launcher not ready!;netstat -tunlp | grep -q 20000"},
+									Command: []string{"/bin/sh", "-c", "wget -O - --no-verbose --no-check-certificate https://kubernetes.default.svc/api/v1/namespaces/default/pods/$HOSTNAME/log?container=rhino-mpi-launcher --header \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" |grep HYDRA_LAUNCH_END"},
 								},
 							},
-							PeriodSeconds:    1,
-							FailureThreshold: 15,
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
+							FailureThreshold:    1,
 						},
 					}},
 					RestartPolicy: "Never",


### PR DESCRIPTION
1. change StartupProbe to ReadinessProbe to avoid job failing for slow launching
2. change the criteria for health check to find "HYDRA_LAUNCH_END" which means "launch end" literally. This will ensure that the health check is declared successful only after the launcher is truly ready.
3. create some RBAC resources to allow the readinessProbe to function properly.

This is a **DRAFT**, not fully tested and the security impacts not evaluated, **DON'T** merge.