### PR TITLE
Removed absolute path to hydra_pmi_proxy in cmdArgs of worker pods to improve compatibility

### DIFF
--- a/internal/controller/rhinojob_controller.go
+++ b/internal/controller/rhinojob_controller.go
@@ -312,7 +312,7 @@ func (r *RhinoJobReconciler) constructWorkersJob(rj *rhinooprapiv1alpha2.RhinoJo
 	var foundPodList kcorev1.PodList
 	r.List(ctx, &foundPodList, client.MatchingLabels(launcherPodLabels))
 	completionMode := "Indexed"
-	cmdArgs := []string{"-c", "/usr/local/bin/hydra_pmi_proxy --control-port " + foundPodList.Items[0].Status.PodIP +
+	cmdArgs := []string{"-c", "hydra_pmi_proxy --control-port " + foundPodList.Items[0].Status.PodIP +
 		":20000 --debug --rmk user --launcher manual --demux poll --pgid 0 --retries 10 --usize -2 --proxy-id $JOB_COMPLETION_INDEX"}
 
 	// 构造 Workers Job


### PR DESCRIPTION
In some images, the hydra_pmi_proxy is placed in /usr/local/bin/, while in others, it is placed in /usr/bin/, as indicated in the log of the launcher task - "Launch arguments: /usr/bin/hydra_pmi_proxy --control-port wrf-2-875ef-launcher-6wtjf:20000 ...". 
In this pull request, the absolute path has been removed to ensure compatibility. It won't impact the functionality of worker pods, as both /usr/bin and /usr/local/bin are default paths for executables.